### PR TITLE
fix(one2many search): modify function to extend search function

### DIFF
--- a/external_addons/one2many_search_widget/static/src/fields/one2manysearch/one2manysearch.js
+++ b/external_addons/one2many_search_widget/static/src/fields/one2manysearch/one2manysearch.js
@@ -6,11 +6,24 @@ export class One2ManySearch extends X2ManyField {
 //  Override to include the onInputKeyUp method.
 //  Whenever text is entered into the search input box, it dynamically
 //  filters the content of the One2Many field to display only matching records
-    onInputKeyUp() {
+    async onInputKeyUp() {
         var value = $(event.currentTarget).val().toLowerCase();
         $(".o_list_table tr:not(:lt(1))").filter(function() {
             $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
         });
+
+        // Adjust the tree limit to 1000 when searching
+        // So that search function can search from all records instead from the records in the paginated one
+        const list = this.list;
+        let offset = 0;
+        let limit = 40;
+        if (list && list.limit) {
+            if (value) {
+                limit = 1000;
+            }
+            await list.load({ limit, offset });
+            this.render();
+        }
     }
 }
 One2ManySearch.template = "One2ManySearchTemplate";


### PR DESCRIPTION
- adjust the tree limit to 1000 when searching so that search function can search from all records instead from the records in the paginated one