### PR TITLE
feat(inventory): fix automated consignment delivery function

### DIFF
--- a/addons/abp_inventory/models/__init__.py
+++ b/addons/abp_inventory/models/__init__.py
@@ -1,5 +1,6 @@
 from . import stock_landed_cost
 from . import stock_location
 from . import stock_picking
+from . import stock_move
 from . import res_partner
 from . import product_template

--- a/addons/abp_inventory/models/stock_move.py
+++ b/addons/abp_inventory/models/stock_move.py
@@ -1,0 +1,12 @@
+from odoo import models, _
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+    
+    def _update_reserved_quantity(self, need, location_id, quant_ids=None, lot_id=None, package_id=None, owner_id=None, strict=True):
+        # If picking is a monthly automated consignment delivery order
+        if 'lastcall' in self.env.context: # Use this to make sure it is from scheduled actions (ir.cron)
+        # if self.picking_id and self.picking_id.partner_id == self.picking_id.location_id.target_partner_id:
+            strict = True
+        return super()._update_reserved_quantity(need, location_id, quant_ids=None, lot_id=None, package_id=None, owner_id=None, strict=strict)

--- a/addons/abp_inventory/models/stock_picking.py
+++ b/addons/abp_inventory/models/stock_picking.py
@@ -44,8 +44,8 @@ class StockPicking(models.Model):
                 'picking_id': stock_picking.id,
                 'product_id': quant.product_id.id,
                 'product_uom_qty': quant.quantity,
-                'location_id': delivery_location.target_partner_id.property_stock_customer.id,
-                'location_dest_id': delivery_location.id
+                'location_id': delivery_location.id,
+                'location_dest_id': delivery_location.target_partner_id.property_stock_customer.id,
             })
         
         # Validate the picking


### PR DESCRIPTION
- switch the picking source location and destination location as before is wrongly assigned
- add logic to strictly take quantity from WH/Consignment, not from the child (if it is an automated consignment delivery order)