### PR TITLE
[IMP] abp_security: hide several action buttons

### DIFF
--- a/addons/abp_security/views/sale_order_views.xml
+++ b/addons/abp_security/views/sale_order_views.xml
@@ -36,5 +36,17 @@
                 </xpath>
             </field>
         </record>
+        
+        <record id="sale_order_tree" model="ir.ui.view">
+            <field name="name">sale.order.tree.abp.security</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.sale_order_tree"/>
+            <field name="arch" type="xml">
+                <!-- Button "Create Invoices" -->
+                <xpath expr="//button[@name='%(sale.action_view_sale_advance_payment_inv)d']" position="attributes">
+                    <attribute name="groups">abp_security.group_administrator</attribute>
+                </xpath>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/abp_security/views/stock_picking_views.xml
+++ b/addons/abp_security/views/stock_picking_views.xml
@@ -9,6 +9,10 @@
                 <xpath expr="//button[@name='action_confirm']" position="attributes">
                     <attribute name="groups">abp_security.abp_group_inventory_button_todo</attribute>
                 </xpath>
+                <!-- Button "Cancel" -->
+                <xpath expr="//button[@name='action_cancel']" position="attributes">
+                    <attribute name="groups">abp_security.group_administrator,abp_security.group_supervisor</attribute>
+                </xpath>
                 <xpath expr="//form[1]/header[1]/button[@name='button_validate']" position="attributes">
                     <attribute name="groups">abp_security.abp_group_inventory_button_validate</attribute>
                 </xpath>
@@ -46,6 +50,18 @@
             <field name="arch" type="xml">
                 <xpath expr="//button[@name='action_toggle_is_locked']" position="attributes">
                     <attribute name="groups">abp_security.group_administrator,abp_security.group_supervisor</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="vpicktree" model="ir.ui.view">
+            <field name="name">stock.picking.view.tree.abp.security</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.vpicktree"/>
+            <field name="arch" type="xml">
+                <!-- Button "Unreserve" -->
+                <xpath expr="//button[@name='do_unreserve']" position="attributes">
+                    <attribute name="groups">abp_security.group_administrator</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Requested by Able Pack because they wanted to hide the buttons for specific role.

Button hid from non-administrator role:
- Button "Unreserve" in Internal Transfer/Delivery Order list view (stock.picking)
- Button "Create Invoices" in Quotations/Sale Order list view (sale.order)

Button hid from salesperson role:
- Button "Cancel" in Internal Transfer form view (stock.picking)

Ref:
- Maintenance #2
- Maintenance #3
- Maintenance #15