### PR TITLE
[ADD] abp_autofill_landed_cost_lines_account: New module to accomodat…

### DIFF
--- a/addons/abp_autofill_landed_cost_lines_account/__init__.py
+++ b/addons/abp_autofill_landed_cost_lines_account/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/abp_autofill_landed_cost_lines_account/__manifest__.py
+++ b/addons/abp_autofill_landed_cost_lines_account/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    'name': 'Able Pack - Autofill Landed Cost Line Account',
+    'category': '',
+    'sequence': 23,
+    'summary': 'Able Pack - Autofill Landed Cost Line Account',
+    'version': '17.0',
+    'description': """
+    """,
+    'depends': [
+        'stock_landed_costs',
+        'account'
+    ],
+    'data': [
+    ],
+    'assets': {
+    },
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'license': 'LGPL-3',
+}

--- a/addons/abp_autofill_landed_cost_lines_account/models/__init__.py
+++ b/addons/abp_autofill_landed_cost_lines_account/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move
+from . import stock_landed_cost

--- a/addons/abp_autofill_landed_cost_lines_account/models/account_move.py
+++ b/addons/abp_autofill_landed_cost_lines_account/models/account_move.py
@@ -1,0 +1,16 @@
+from odoo import models, _
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+    
+    def button_create_landed_costs(self):
+        res = super().button_create_landed_costs()
+        stock_landed_cost_lines = self.env['stock.landed.cost.lines'].search([
+                                        ('cost_id', '=', res['res_id'])
+                                    ])
+        for line in stock_landed_cost_lines:
+            line.write({
+                'account_id': line.product_id.property_account_expense_id
+            })
+        return res

--- a/addons/abp_autofill_landed_cost_lines_account/models/stock_landed_cost.py
+++ b/addons/abp_autofill_landed_cost_lines_account/models/stock_landed_cost.py
@@ -8,5 +8,3 @@ class StockLandedCostLine(models.Model):
     def onchange_product_id(self):
         super().onchange_product_id()
         self.account_id = self.product_id.property_account_expense_id
-        
-        

--- a/addons/abp_inventory/__manifest__.py
+++ b/addons/abp_inventory/__manifest__.py
@@ -9,7 +9,6 @@
     'depends': [
         'product',
         'stock',
-        'stock_landed_costs',
         'abp_report'
     ],
     'data': [

--- a/addons/abp_inventory/models/__init__.py
+++ b/addons/abp_inventory/models/__init__.py
@@ -1,4 +1,3 @@
-from . import stock_landed_cost
 from . import stock_location
 from . import stock_picking
 from . import stock_move

--- a/docs/install.md
+++ b/docs/install.md
@@ -51,3 +51,5 @@ install contacts
 install web_studio
 install partner_commission
 
+May 30, 2025:
+- install abp_autofill_landed_cost_lines_account


### PR DESCRIPTION
…e Able Pack landed cost logic

Requested by Able Pack because they wanted the landed cost lines account to be filled automatically from the account configured in the product.

Removed particular code in abp_inventory and move it to this module, because we want to make it more modular.

Autofill when landed cost:
- Created from vendor bill
- Created directly in the landed cost form

References:
- Maintenance no. 14