### PR TITLE
[ADD] vt_bom_kit_constraint: Show on-hand qty in inventory transfer l…

### DIFF
--- a/addons/vt_bom_kit_constraint/models/stock_move.py
+++ b/addons/vt_bom_kit_constraint/models/stock_move.py
@@ -1,7 +1,11 @@
-from odoo import _, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
     
-    bom_parent_qty = fields.Float(readonly=True)
+    @api.onchange('product_uom_qty')
+    def _onchange_product_uom_qty(self):
+        if self.product_uom_qty > self.product_qty_available:
+            raise ValidationError(_('Demand cannot be greater than on-hand quantity.'))

--- a/addons/vt_bom_kit_constraint/views/stock_picking_views.xml
+++ b/addons/vt_bom_kit_constraint/views/stock_picking_views.xml
@@ -10,7 +10,7 @@
                     <button name="button_populate_minimum_bom_qty" icon="fa-bullseye" string="Populate Minimum BOM Quantity" type="object" class="btn btn-warning"/>
                 </button>
                 <xpath expr="//field[@name='move_ids_without_package']/tree/field[@name='product_uom_qty']" position="before">
-                    <field name="bom_parent_qty"/>
+                    <field name="product_qty_available" string="On-Hand Qty"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
…ines

Requested by Able Pack because they wanted the user to know the current on-hand qty of the selected product, so that, the user will not key in the higher demand qty than the on-hand qty.

Also, the system will show validation error if the user key in higher deman qty than the on-hand qty.

References:
- Maintenance no. 20
- Maintenance no. 25