### PR TITLE
[FIX] abp_inventory: Fix automated delivery order scheduler

### DIFF
--- a/addons/abp_inventory/data/ir_cron.xml
+++ b/addons/abp_inventory/data/ir_cron.xml
@@ -7,6 +7,7 @@
             <field name="state">code</field>
             <field name="code">model.create_delivery_from_consignment_location()</field>
             <field name="user_id" ref="base.user_admin"/>
+            <field name="numbercall">-1</field>
             <field name="interval_number">1</field>
             <field name="interval_type">months</field>
         </record>


### PR DESCRIPTION
Minor bug, the scheduler was not running simply because the numbercall was set to 0. Now, the numbercall has been set to -1, which means the scheduler will run indefinitely (no limit).